### PR TITLE
Add basic cross-platform LLM wallpaper tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore generated images
+wallpaper.png
+screenshot.png
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # llm-wallpaper
-Using LLMs to generate your wallpaper for you based on whatever criteria you select
+
+`llm-wallpaper` is an experimental cross-platform Python application that uses an LLM to help generate wallpapers. It works on macOS and Windows and can be extended to pull various inputs such as screenshots or recent X posts to influence the wallpaper prompt.
+
+## Features
+
+- Generate wallpapers using your favorite LLM provider.
+- Works on macOS and Windows.
+- Change wallpapers on a schedule or on demand.
+- Customize the prompt sent to the LLM.
+- Optional inputs such as screenshots or X posts can be added.
+
+## Installation
+
+```bash
+# Clone the repository and install dependencies
+pip install -r requirements.txt
+```
+
+You will need an API key for a provider that supports image generation (for example, OpenAI). Set the key using an environment variable or pass `--llm-key` on the command line.
+
+## Usage
+
+```bash
+python wallpaper.py --prompt "sunset over mountains" --interval 60 --inputs screenshot
+```
+
+Arguments:
+
+- `--llm-key` – API key for the LLM. Can also be provided via `OPENAI_API_KEY`.
+- `--prompt` – Base prompt for the LLM.
+- `--interval` – Interval (minutes) for changing the wallpaper. If omitted, a single wallpaper is generated.
+- `--inputs` – Comma-separated list of inputs (e.g. `screenshot,xposts`).
+
+## Contributing
+
+Contributions are welcome! Fork the repo and submit a pull request. Please follow standard Python formatting via `black` and keep changes focused. For major features, open an issue first to discuss your ideas.
+
+1. Fork the repository and create your branch.
+2. Commit your changes with clear messages.
+3. Open a pull request describing your changes.
+
+## Donations
+
+If you find this project useful, consider donating to help sustain development.
+
+- BTC: `bc1qq7tsvfkfcyaqy8jxz9n3v93h0uw6frw0p4jau5`
+
+## License
+
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+pyautogui
+requests

--- a/wallpaper.py
+++ b/wallpaper.py
@@ -1,0 +1,103 @@
+import argparse
+import os
+import platform
+import subprocess
+import sys
+import time
+from typing import List
+
+try:
+    import openai
+except ImportError:
+    print("openai package not found. Install with `pip install openai`.")
+    sys.exit(1)
+
+try:
+    import pyautogui
+except ImportError:
+    pyautogui = None
+
+
+def set_wallpaper(path: str):
+    system = platform.system()
+    if system == "Windows":
+        import ctypes
+        ctypes.windll.user32.SystemParametersInfoW(20, 0, path, 3)
+    elif system == "Darwin":
+        script = f'tell application "System Events" to set picture of every desktop to POSIX file "{path}"'
+        subprocess.run(["osascript", "-e", script], check=True)
+    else:
+        print(f"Setting wallpaper not implemented for {system}.")
+
+
+def capture_screenshot() -> str:
+    if not pyautogui:
+        raise RuntimeError("pyautogui is required for screenshot input")
+    screenshot = pyautogui.screenshot()
+    path = os.path.join(os.getcwd(), "screenshot.png")
+    screenshot.save(path)
+    return path
+
+
+def fetch_x_posts() -> str:
+    # Placeholder for fetching posts from X (Twitter)
+    # In a real implementation, use the X API with the user's credentials
+    return ""
+
+
+def generate_prompt(base_prompt: str, inputs: List[str]) -> str:
+    details = []
+    for item in inputs:
+        if item == "screenshot":
+            path = capture_screenshot()
+            details.append(f"Screenshot saved at {path}")
+        elif item == "xposts":
+            posts = fetch_x_posts()
+            details.append(f"Recent X posts: {posts}")
+    if details:
+        base_prompt += "\n" + "\n".join(details)
+    return base_prompt
+
+
+def generate_wallpaper(llm_key: str, prompt: str) -> str:
+    openai.api_key = llm_key
+    response = openai.Image.create(prompt=prompt, n=1, size="1024x1024")
+    url = response['data'][0]['url']
+    import requests
+    img_data = requests.get(url).content
+    path = os.path.join(os.getcwd(), "wallpaper.png")
+    with open(path, 'wb') as f:
+        f.write(img_data)
+    return path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate wallpaper with LLM")
+    parser.add_argument("--llm-key", help="API key for the LLM", default=os.getenv("OPENAI_API_KEY"))
+    parser.add_argument("--prompt", help="Prompt for the LLM", default="Create a beautiful wallpaper")
+    parser.add_argument("--interval", type=int, help="Interval in minutes for changing wallpaper")
+    parser.add_argument("--inputs", default="", help="Comma separated inputs like screenshot,xposts")
+    args = parser.parse_args()
+
+    if not args.llm_key:
+        print("Missing LLM API key. Provide with --llm-key or OPENAI_API_KEY.")
+        return
+
+    input_list = [i.strip() for i in args.inputs.split(',') if i.strip()]
+
+    def run_cycle():
+        final_prompt = generate_prompt(args.prompt, input_list)
+        img_path = generate_wallpaper(args.llm_key, final_prompt)
+        set_wallpaper(img_path)
+        print(f"Wallpaper updated with prompt: {final_prompt}")
+
+    if args.interval:
+        while True:
+            run_cycle()
+            time.sleep(args.interval * 60)
+    else:
+        run_cycle()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `wallpaper.py` to generate wallpapers using OpenAI and set them on macOS or Windows
- add dependency list in `requirements.txt`
- update README with installation, usage, contribution and donation info
- ignore generated files via `.gitignore`

## Testing
- `python -m py_compile wallpaper.py`


------
https://chatgpt.com/codex/tasks/task_e_686d7f7fd258832da54261f98b6e0306